### PR TITLE
renew {{ domain }}.pem

### DIFF
--- a/roles/cert_bot/handlers/main.yml
+++ b/roles/cert_bot/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+- name: Start snap.certbot.renew
+  ansible.builtin.systemd:
+    service: snap.certbot.renew.service
+    state: restarted

--- a/roles/cert_bot/tasks/main.yaml
+++ b/roles/cert_bot/tasks/main.yaml
@@ -60,6 +60,22 @@
     #   ansible.builtin.debug:
     #     var: newcerts
 
+    - name: Autocreate update
+      ansible.builtin.template:
+        src: cat-after-certbot.service.j2
+        dest: /etc/systemd/system/cat-after-certbot.service
+        owner: root
+        group: root
+        mode: "0644"
+
+    - name: Detect new service
+      ansible.builtin.systemd:
+        daemon_reload: true
+        service: cat-after-certbot
+        enabled: true
+      notify:
+        - Start snap.certbot.renew
+
     - name: Create sum.crt
       shell: >
         cat /etc/letsencrypt/live/{{ domain }}/fullchain.pem

--- a/roles/cert_bot/templates/cat-after-certbot.service.j2
+++ b/roles/cert_bot/templates/cat-after-certbot.service.j2
@@ -1,0 +1,16 @@
+[Unit]
+Description=crt update after certbot has run
+After=snap.certbot.renew.service
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/sh -c "if \
+    [ {{ tls_pem_path }} -ot /etc/letsencrypt/live/{{ domain }}/privkey.pem ] || \
+    [ {{ tls_pem_path }} -ot /etc/letsencrypt/live/{{ domain }}/fullchain.pem ]; \
+    then \
+    cat /etc/letsencrypt/live/{{ domain }}/fullchain.pem \
+    /etc/letsencrypt/live/{{ domain }}/privkey.pem > {{ tls_pem_path }}; \
+    fi"
+
+[Install]
+WantedBy=snap.certbot.renew.service


### PR DESCRIPTION
Adds an additional service, executed after certbot.renew.service to create the pem-file in /etc/ssl/certs/