### PR TITLE
k8s: introduce new repo pkgs.k8s.io

### DIFF
--- a/roles/kubeadm-installer/tasks/Debian.yml
+++ b/roles/kubeadm-installer/tasks/Debian.yml
@@ -3,14 +3,15 @@
 # NOTE: In Debian11 selinux seems to be disabled by default
 #
 - name: Add repo key
-  ansible.builtin.apt_key:
+  get_url:
     url: "https://pkgs.k8s.io/core:/stable:/v1.28/deb/Release.key"
-    state: present
+    dest: /etc/apt/keyrings/kubernetes-apt-keyring.asc
+    mode: '0644'
+    force: true
 
 - name: Add repo
   ansible.builtin.apt_repository:
     repo: "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.asc] https://pkgs.k8s.io/core:/stable:/v1.28/deb/ /"
-    filename: kubernetes
     state: present
     update_cache: yes
 

--- a/roles/kubeadm-installer/tasks/Debian.yml
+++ b/roles/kubeadm-installer/tasks/Debian.yml
@@ -4,12 +4,12 @@
 #
 - name: Add repo key
   ansible.builtin.apt_key:
-    url: "https://pkgs.k8s.io/core:/stable:/v1.29/deb/Release.key"
+    url: "https://pkgs.k8s.io/core:/stable:/v1.28/deb/Release.key"
     state: present
 
 - name: Add repo
   ansible.builtin.apt_repository:
-    repo: "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.asc] https://pkgs.k8s.io/core:/stable:/v1.29/deb/ /"
+    repo: "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.asc] https://pkgs.k8s.io/core:/stable:/v1.28/deb/ /"
     filename: kubernetes
     state: present
     update_cache: yes

--- a/roles/kubeadm-installer/tasks/Debian.yml
+++ b/roles/kubeadm-installer/tasks/Debian.yml
@@ -2,18 +2,15 @@
 
 # NOTE: In Debian11 selinux seems to be disabled by default
 #
-- name: Add repo key
-  get_url:
-    url: "https://pkgs.k8s.io/core:/stable:/v1.28/deb/Release.key"
-    dest: /etc/apt/keyrings/kubernetes-apt-keyring.asc
-    mode: '0644'
-    force: true
-
-- name: Add repo
-  ansible.builtin.apt_repository:
-    repo: "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.asc] https://pkgs.k8s.io/core:/stable:/v1.28/deb/ /"
+- name: Add Kubernetes apt repository key
+  ansible.builtin.apt_key:
+    url: https://pkgs.k8s.io/core:/stable:/v1.28/deb/Release.key
     state: present
-    update_cache: yes
+
+- name: Add Kubernetes apt repository
+  ansible.builtin.copy:
+    content: 'deb [signed-by=/etc/apt/trusted.gpg.d/kubernetes-archive-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.28/deb/ /'
+    dest: /etc/apt/sources.list.d/kubernetes.list
 
 - name: Add some packages
   ansible.builtin.apt:

--- a/roles/kubeadm-installer/tasks/Debian.yml
+++ b/roles/kubeadm-installer/tasks/Debian.yml
@@ -4,14 +4,15 @@
 #
 - name: Add repo key
   ansible.builtin.apt_key:
-    url: "https://packages.cloud.google.com/apt/doc/apt-key.gpg"
+    url: "https://pkgs.k8s.io/core:/stable:/v1.29/deb/Release.key"
     state: present
 
 - name: Add repo
   ansible.builtin.apt_repository:
-    repo: "deb https://apt.kubernetes.io/ kubernetes-xenial main"
+    repo: "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.asc] https://pkgs.k8s.io/core:/stable:/v1.29/deb/ /"
     filename: kubernetes
     state: present
+    update_cache: yes
 
 - name: Add some packages
   ansible.builtin.apt:

--- a/update-k8s-repo.yml
+++ b/update-k8s-repo.yml
@@ -1,5 +1,5 @@
 ---
-- name: Configure Kubernetes Repository
+- name: Configure Kubernetes and Docker Repositories
   hosts: all
   become: true
   tasks:
@@ -12,6 +12,17 @@
       shell: curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.28/deb/Release.key | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
       args:
         executable: /bin/bash
+
+    - name: Add Docker GPG key to APT keyring
+      apt_key:
+        url: https://download.docker.com/linux/debian/gpg
+        state: present
+
+    - name: Create Docker repository configuration file
+      lineinfile:
+        path: /etc/apt/sources.list.d/docker.list
+        line: "deb [arch=amd64 signed-by=/etc/apt/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/debian {{ ansible_distribution_release }} stable"
+        create: yes
 
     - name: Update APT package lists
       apt:

--- a/update-k8s-repo.yml
+++ b/update-k8s-repo.yml
@@ -1,0 +1,18 @@
+---
+- name: Configure Kubernetes Repository
+  hosts: all
+  become: true
+  tasks:
+    - name: Add Kubernetes repository
+      shell: echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.28/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list
+      args:
+        executable: /bin/bash
+
+    - name: Download Kubernetes GPG key
+      shell: curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.28/deb/Release.key | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+      args:
+        executable: /bin/bash
+
+    - name: Update APT package lists
+      apt:
+        update_cache: yes

--- a/update-k8s-repo.yml
+++ b/update-k8s-repo.yml
@@ -3,6 +3,19 @@
   hosts: all
   become: true
   tasks:
+
+    - name: Download Docker GPG key
+      get_url:
+        url: "https://download.docker.com/linux/debian/gpg"
+        dest: "/usr/share/keyrings/docker-archive-keyring.gpg"
+
+    - name: Add Docker repository to APT sources.list.d
+      lineinfile:
+        dest: "/etc/apt/sources.list.d/docker.list"
+        line: "deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/debian {{ ansible_distribution_release }} stable"
+        create: yes
+
+
     - name: Add Kubernetes repository
       shell: echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.28/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list
       args:


### PR DESCRIPTION
[Migrate docs](https://kubernetes.io/blog/2023/08/15/pkgs-k8s-io-introduction/#how-to-migrate)

## migrate
```bash

# remove old docker keys
sudo rm /etc/apt/keyrings/docker.gpg
sudo rm /etc/apt/sources.list.d/docker.list

# remove old k8s key
sudo rm -r /etc/apt/sources.list.d/kubernetes.list

# Download the public signing key for the Kubernetes package repositories. The same signing key is used for all repositories so you can disregard the version in the URL:
curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.29/deb/Release.key | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg

# Add the appropriate Kubernetes apt repository
echo 'deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.29/deb/ /' | sudo tee /etc/apt/sources.list.d/kubernetes.list

# update
apt-get update

```